### PR TITLE
Add table stripes to the scorecard

### DIFF
--- a/app/views/feedbacks/_form.html.haml
+++ b/app/views/feedbacks/_form.html.haml
@@ -28,7 +28,7 @@
     .col-sm-2.control-label
       %strong= Bmark.model_name.human.pluralize
     .col-sm-10
-      %table{ width: '100%' }
+      %table.table-striped{ width: '100%' }
         %thead
           %tr
             %th


### PR DESCRIPTION
When there are a number of benchmarks, and especially of those
benchmarks are "wordy" it's difficult to line up the benchmark with the
score.