### PR TITLE
Make sure scores are also deleted with benchmarks

### DIFF
--- a/app/models/bmark.rb
+++ b/app/models/bmark.rb
@@ -2,6 +2,7 @@ class Bmark < ActiveRecord::Base
   belongs_to :track
   belongs_to :stage
   has_many :sign_offs, dependent: :destroy
+  has_many :scores, dependent: :destroy
   validates :name, presence: true
 
   def self.by_stage_and_track

--- a/spec/models/bmark_spec.rb
+++ b/spec/models/bmark_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Bmark, type: :model do
   it { should belong_to :track }
   it { should belong_to :stage }
   it { should have_many(:sign_offs).dependent(:destroy) }
+  it { should have_many(:scores).dependent(:destroy) }
   it { should validate_presence_of :name }
 
   describe '::by_stage_and_track' do


### PR DESCRIPTION
I added the `destroy` for sign_offs, but missed "scores". This fixes
that.
[finsihes #119338335]
